### PR TITLE
Fix dependencies resolution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.25.1
+requests~=2.25


### PR DESCRIPTION
Hi, I noticed an issue with dependencies resolution for this package, when using poetry. The problem was that the version of the `requests` package was fixed to `2.25.0`, and so preventing any update of future versions of the `requests` package.

This PR fix this by updating the requirements to `request~=2.25`, thus allowing any `2.x.x` version greater than `2.25.0`.

Can you please also consider open an "Issues" tab so that we can suggest other fix? By the way, thanks for updating the original library!